### PR TITLE
add_negative_examples

### DIFF
--- a/datasets/binary_datasets/binary_dataset.py
+++ b/datasets/binary_datasets/binary_dataset.py
@@ -1,16 +1,26 @@
 import numpy as np
 import random
+from datasets.LUDB_utils import get_signal_by_id_and_lead_mV, get_one_lead_delineation_by_patient_id
+from settings import FREQUENCY
 
 
 class BinaryDataset:
-    def __init__(self, name, signals_train, signals_test, labels_train, labels_test, full_signals, delineation_on_full_signals):
+    def __init__(self, name, signals_train, signals_test, labels_train, labels_test,
+                 full_signals, delineation_on_full_signals,
+                 lead_name, point_name, radius):
+
         self.name = name
         self.signals_train = signals_train
         self.signals_test = signals_test
         self.labels_train = labels_train
         self.labels_test = labels_test
+
         self.full_signals = full_signals
         self.delineation_on_full_signals = delineation_on_full_signals
+
+        self.lead_name = lead_name
+        self.point_name = point_name
+        self.radius = radius
 
 
     def get_test(self):
@@ -78,3 +88,39 @@ class BinaryDataset:
             self.delineation_on_full_signals = np.concatenate([self.delineation_on_full_signals, np.array(new_delineation_on_full_signals)])
 
         print(f"Добавлено {len(new_signals)} примеров с джиттером")
+
+
+    def add_negative_examples(self, shift, num_examples, LUDB_dataset):
+        if num_examples <= 0:
+            raise ValueError("num_examples должно быть > 0")
+
+        radius = self.radius
+        lead_name = self.lead_name
+        point_name = self.point_name
+
+        new_signals = []
+        new_full_signals = []
+        new_delineation_on_full_signals = []
+
+        patient_ids = list(LUDB_dataset.keys())
+
+        while len(new_signals) < num_examples:
+            patient_id = random.choice(patient_ids)
+            delineation_by_point_name = get_one_lead_delineation_by_patient_id(patient_id, LUDB_dataset, lead_name, point_name)
+            signal = get_signal_by_id_and_lead_mV(patient_id, lead_name, LUDB_dataset)
+
+            if len(delineation_by_point_name) > 0:
+                selected_point_name = int(random.choice(delineation_by_point_name) * FREQUENCY)
+                new_center = selected_point_name + shift
+                if (new_center - radius >= 0) and (new_center + radius < len(signal)):
+                    new_signals.append(signal[new_center - radius:new_center + radius])
+                    new_full_signals.append(signal)
+                    new_delineation_on_full_signals.append(new_center)
+
+        if new_signals:
+            self.signals_train = np.concatenate([self.signals_train, np.array(new_signals)])
+            self.labels_train = np.concatenate([self.labels_train, np.zeros(len(new_signals), dtype=int)])
+            self.full_signals = np.concatenate([self.full_signals, np.array(new_full_signals)])
+            self.delineation_on_full_signals = np.concatenate([self.delineation_on_full_signals, np.array(new_delineation_on_full_signals)])
+
+        print(f"Добавлено {len(new_signals)} негативных примеров")

--- a/datasets/binary_datasets/binary_dataset_creator.py
+++ b/datasets/binary_datasets/binary_dataset_creator.py
@@ -74,7 +74,10 @@ def create_dataset_from_scratch(point_name, radius, lead_name, LUDB_dataset, dat
         labels_train=np.array(labels_train),
         labels_test=labels_test,
         full_signals=np.array(full_signals),
-        delineation_on_full_signals=np.array(delineation_on_full_signals)
+        delineation_on_full_signals=np.array(delineation_on_full_signals),
+        lead_name = lead_name,
+        point_name = point_name,
+        radius = radius
     )
 
     binary_dataset.shuffle()

--- a/datasets/binary_datasets/example.py
+++ b/datasets/binary_datasets/example.py
@@ -35,3 +35,15 @@ if __name__ == "__main__":
 
     # Листаем его в UI с визуализацией картинок
     binary_dataset_visualizator = UIBinaryDataset(binary_dataset)
+
+
+    bin_datset_with_nigative = create_dataset_from_scratch(point_name=POINTS_TYPES.T_PEAK,
+                                                 radius=200,
+                                                 lead_name=LEADS_NAMES.ii,
+                                                 LUDB_dataset=LUDB_dataset,
+                                                 dataset_size=50
+                                                )
+
+    bin_datset_with_nigative.add_negative_examples(-20, 100, LUDB_dataset)
+
+    bin_datset_with_nigative_visual = UIBinaryDataset(bin_datset_with_nigative)

--- a/datasets/binary_datasets/serialization.py
+++ b/datasets/binary_datasets/serialization.py
@@ -27,7 +27,10 @@ def load_binary_dataset_from_file(name, save_dir="SAVED_DATASETS"):
         labels_train=np.array(dataset_dict["labels_train"]),
         labels_test=np.array(dataset_dict["labels_test"]),
         full_signals=np.array(dataset_dict["full_signals"]),
-        delineation_on_full_signals=np.array(dataset_dict["delineation_on_full_signals"])
+        delineation_on_full_signals=np.array(dataset_dict["delineation_on_full_signals"]),
+        lead_name = dataset_dict["lead_name"],
+        point_name = dataset_dict["point_name"],
+        radius = dataset_dict["radius"]
     )
     return binary_dataset
 
@@ -52,7 +55,10 @@ def save_binary_dataset_to_file(binary_dataset, save_dir="SAVED_DATASETS"):
         "labels_train": binary_dataset.labels_train.tolist(),
         "labels_test": binary_dataset.labels_test.tolist(),
         "full_signals": binary_dataset.full_signals.tolist(),
-        "delineation_on_full_signals": binary_dataset.delineation_on_full_signals.tolist()
+        "delineation_on_full_signals": binary_dataset.delineation_on_full_signals.tolist(),
+        "lead_name" : binary_dataset.lead_name,
+        "point_name" : binary_dataset.point_name,
+        "radius" : binary_dataset.radius
     }
 
     filename = os.path.join(save_path, f"{binary_dataset.name}.json")


### PR DESCRIPTION
## Добавлен метод негативных примеров

**Изменения:**
1. Добавлен метод add_negative_examples(self, shift, num_examples, LUDB_dataset)
**Алгоритм:**
Принимает сдвиг(shift) от точки разметки: положительный - сдвиг вправо, отрицательный - влево, количество добавляемых примеров(num_examples), датасет для забора примеров. Радиус, отведение, тип точки подтягиваются из самого бинарного датасета. Выбирается случайные пациент из LUDB в характерном отведении выбирается случайная врачебная разметка для соответствующего типа точки и производится сдвиг, определяется новый центр окна и это окно вырезается затем добавляется в новый массив, все остальные данные нужные для структуры класса бинарного датасета тоже сохраняются. По достижении нужного количества примеров происходит конкатенация данных исходного бинарного датасета с собранными примерами.
2. Изменены BinaryDataset и create_dataset_from_scratch для корректной работы нового метода
3. В example представлен пример работы нового метода(если требуется перемешать данные в датасете можно использовать метод shuffle: bin_datset_with_nigative.shuffle())